### PR TITLE
Remove not_null tests from revenue metrics

### DIFF
--- a/dbt-project/models/marts/metrics_conversion_rates.yml
+++ b/dbt-project/models/marts/metrics_conversion_rates.yml
@@ -55,11 +55,7 @@ models:
       - name: total_revenue
         description: "The total revenue generated from purchase sessions."
         data_type: float
-        tests:
-          - not_null
       - name: avg_order_value
         description: "The average order value for purchase sessions."
         data_type: float
-        tests:
-          - not_null
       


### PR DESCRIPTION
Removed not_null tests for total_revenue and avg_order_value.