### PR TITLE
Extract churn thresholds to configurable dbt vars

### DIFF
--- a/dbt-project/dbt_project.yml
+++ b/dbt-project/dbt_project.yml
@@ -23,5 +23,13 @@ models:
       +schema: marts
       +materialized: table
 
+vars:
+  # Churn classification thresholds (days since last purchase)
+  churn_threshold_days: 60
+  at_risk_threshold_days: 45
+  declining_threshold_days: 30
+  # Cohort analysis observation window
+  cohort_observation_window_days: 90
+
 flags:
   send_anonymous_usage_stats: False

--- a/dbt-project/models/marts/dim_users.sql
+++ b/dbt-project/models/marts/dim_users.sql
@@ -116,20 +116,30 @@ churn_classified as (
 
         case
             when
-                purchase_count > 0 and days_since_last_purchase > 60
+                purchase_count > 0
+                and days_since_last_purchase
+                > {{ var('churn_threshold_days') }}
                 then 'churned'
             when
-                purchase_count > 0 and days_since_last_purchase > 45
+                purchase_count > 0
+                and days_since_last_purchase
+                > {{ var('at_risk_threshold_days') }}
                 then 'at_risk'
             when
-                purchase_count > 0 and days_since_last_purchase > 30
+                purchase_count > 0
+                and days_since_last_purchase
+                > {{ var('declining_threshold_days') }}
                 then 'declining'
             when purchase_count > 0 then 'active'
             else 'prospect'
         end as activity_status,
 
         case
-            when purchase_count > 0 and days_since_last_purchase > 60 then 1
+            when
+                purchase_count > 0
+                and days_since_last_purchase
+                > {{ var('churn_threshold_days') }}
+                then 1
             else 0
         end as is_churned
 

--- a/dbt-project/models/marts/metrics_churn.sql
+++ b/dbt-project/models/marts/metrics_churn.sql
@@ -84,7 +84,7 @@ cohort_eligible_customers as (
     where
         date_diff(
             dataset_range.dataset_end, customers.first_purchase_date, day
-        ) >= 90
+        ) >= {{ var('cohort_observation_window_days') }}
 
 ),
 
@@ -116,7 +116,8 @@ churn_flags as (
         case
             when purchase_count = 1 then 1
             when
-                date_diff(last_purchase_date, first_purchase_date, day) > 90
+                date_diff(last_purchase_date, first_purchase_date, day)
+                > {{ var('cohort_observation_window_days') }}
                 then 0
             else 1
         end as is_churned_cohort


### PR DESCRIPTION
## Summary
- Move hardcoded churn classification thresholds from SQL to `dbt_project.yml` vars
- Enables business users to adjust thresholds without modifying SQL code

### New vars in `dbt_project.yml`:
| Variable | Default | Used in |
|----------|---------|---------|
| `churn_threshold_days` | 60 | `dim_users` |
| `at_risk_threshold_days` | 45 | `dim_users` |
| `declining_threshold_days` | 30 | `dim_users` |
| `cohort_observation_window_days` | 90 | `metrics_churn` |

## Test plan
- [ ] Run `dbt build` to verify models compile and execute correctly
- [ ] Verify churn classifications match previous behavior with default values