### PR TITLE
Add error handling to Dagster sensors

### DIFF
--- a/dagster-project/src/dagster_project/defs/sensors/run_failure_sensor.py
+++ b/dagster-project/src/dagster_project/defs/sensors/run_failure_sensor.py
@@ -24,7 +24,13 @@ def run_failure_sensor(context: RunFailureSensorContext, slack: SlackResource):
 *Run ID:* `{run_id}`
 """.strip()
 
-    slack.get_client().chat_postMessage(
-        channel="#estore-dagster-reports",
-        text=slack_message
-    )
+    try:
+        slack.get_client().chat_postMessage(
+            channel="#estore-dagster-reports",
+            text=slack_message
+        )
+    except Exception as e:
+        context.log.error(
+            f"Failed to send Slack notification: {str(e)}. "
+            f"Original failure: Job '{job_name}' Run ID '{run_id}'"
+        )


### PR DESCRIPTION
## Summary
- Add try-except error handling to `dbt_run_on_load_sensor` to prevent crashes
- Wrap Slack API call in `run_failure_sensor` to prevent cascade failures when Slack is unavailable

## Changes
| File | Change |
|------|--------|
| `dbt_run_on_load_sensor.py` | Wrap function in try-except, return `SkipReason` on error |
| `run_failure_sensor.py` | Wrap Slack call in try-except, log error with original failure context |

## Test plan
- [ ] Verify sensors still function normally in Dagster UI
- [ ] Confirm error logging works when exceptions occur