### PR TITLE
Add profiles.yml.example for new project setup

### DIFF
--- a/dbt-project/profiles.yml.example
+++ b/dbt-project/profiles.yml.example
@@ -1,0 +1,14 @@
+estore:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      project: <your-gcp-project-id>
+      dataset: estore
+      location: US
+      method: service-account
+      keyfile: <path/to/service-account-key.json>
+      job_execution_timeout_seconds: 300
+      job_retries: 1
+      priority: interactive
+      threads: 2


### PR DESCRIPTION
## Summary
- Add `profiles.yml.example` template for users setting up the project
- Uses `estore` as the base dataset, resulting in `estore_staging` and `estore_marts` schemas

## Setup
Copy to `profiles.yml` and replace placeholders with your GCP project details.