### PR TITLE
Add RFM segment snapshot for SCD Type 2 tracking

### DIFF
--- a/dbt-project/snapshots/snap_user_rfm.yml
+++ b/dbt-project/snapshots/snap_user_rfm.yml
@@ -1,0 +1,38 @@
+snapshots:
+  - name: snap_user_rfm
+    description: >
+      SCD Type 2 snapshot tracking changes to user RFM segments over time.
+      Enables segment migration analysis to understand how customers move
+      between segments (e.g., Champion → At Risk → Lost).
+    relation: ref('dim_user_rfm')
+    config:
+      schema: snapshots
+      unique_key: user_id
+      strategy: check
+      check_cols:
+        - rfm_segment
+        - rfm_score
+        - recency_score
+        - frequency_score
+        - monetary_score
+    columns:
+      - name: user_id
+        description: "Unique identifier for each user"
+      - name: rfm_segment
+        description: "RFM segment classification (Champions, At Risk, Loyal Customers, etc.)"
+      - name: rfm_score
+        description: "Composite RFM score (sum of recency, frequency, monetary scores)"
+      - name: recency_score
+        description: "Recency score (1-5) based on days since last purchase"
+      - name: frequency_score
+        description: "Frequency score (1-5) based on purchase count"
+      - name: monetary_score
+        description: "Monetary score (1-5) based on total revenue"
+      - name: dbt_valid_from
+        description: "Timestamp when this version of the record became valid"
+      - name: dbt_valid_to
+        description: "Timestamp when this version was superseded (null if current)"
+      - name: dbt_scd_id
+        description: "Surrogate key for the snapshot record"
+      - name: dbt_updated_at
+        description: "Timestamp when the snapshot record was last updated"


### PR DESCRIPTION
## Summary
- Adds `snap_user_rfm` snapshot using dbt 1.9+ YAML configuration
- Tracks changes to user RFM segments over time (SCD Type 2)
- Enables segment migration analysis (e.g., Champion → At Risk → Lost)

## Changes
- New file: `dbt-project/snapshots/snap_user_rfm.yml`
- Uses `check` strategy on `rfm_segment`, `rfm_score`, and individual score columns

## Test plan
- [x] `dbt compile --select snap_user_rfm` succeeds
- [x] `dbt snapshot --select snap_user_rfm` creates table successfully (2M rows)