### PR TITLE
Add user status snapshot for churn lifecycle tracking

### DIFF
--- a/dbt-project/snapshots/snap_user_status.yml
+++ b/dbt-project/snapshots/snap_user_status.yml
@@ -1,0 +1,37 @@
+snapshots:
+  - name: snap_user_status
+    description: >
+      SCD Type 2 snapshot tracking changes to user activity status and churn
+      classification over time. Enables churn lifecycle analysis to understand
+      how users transition between active, declining, at_risk, and churned states.
+    relation: ref('dim_users')
+    config:
+      schema: snapshots
+      unique_key: user_id
+      strategy: check
+      check_cols:
+        - activity_status
+        - is_churned
+        - customer_ltv
+        - purchase_count
+    columns:
+      - name: user_id
+        description: "Unique identifier for each user"
+      - name: activity_status
+        description: "User activity classification (active, declining, at_risk, churned, prospect)"
+      - name: is_churned
+        description: "Binary flag indicating if user has churned"
+      - name: customer_ltv
+        description: "Customer lifetime value at time of snapshot"
+      - name: purchase_count
+        description: "Total purchases at time of snapshot"
+      - name: days_since_last_purchase
+        description: "Days since last purchase at time of snapshot"
+      - name: dbt_valid_from
+        description: "Timestamp when this version of the record became valid"
+      - name: dbt_valid_to
+        description: "Timestamp when this version was superseded (null if current)"
+      - name: dbt_scd_id
+        description: "Surrogate key for the snapshot record"
+      - name: dbt_updated_at
+        description: "Timestamp when the snapshot record was last updated"


### PR DESCRIPTION
## Summary
- Adds `snap_user_status` snapshot using dbt 1.9+ YAML configuration
- Tracks changes to user activity status over time (SCD Type 2)
- Enables churn lifecycle analysis (active → declining → at_risk → churned)

## Changes
- New file: `dbt-project/snapshots/snap_user_status.yml`
- Uses `check` strategy on `activity_status`, `is_churned`, `customer_ltv`, `purchase_count`

## Test plan
- [x] `dbt compile --select snap_user_status` succeeds
- [x] `dbt snapshot --select snap_user_status` creates table successfully (15.5M rows)