### PR TITLE
Add weekly snapshot job and schedule

### DIFF
--- a/dagster-project/src/dagster_project/defs/jobs/__init__.py
+++ b/dagster-project/src/dagster_project/defs/jobs/__init__.py
@@ -1,18 +1,28 @@
 from dagster import (
-    Definitions, 
-    AssetSelection, 
-    define_asset_job, 
+    Definitions,
+    AssetSelection,
+    define_asset_job,
     job
 )
 from dagster_gcp.bigquery.ops import import_gcs_paths_to_bq
 
 dbt_assets = AssetSelection.groups("dbt_models")
+dbt_snapshots = AssetSelection.assets(
+    ["snapshots", "snap_user_rfm"],
+    ["snapshots", "snap_user_status"]
+)
 
 dbt_job = define_asset_job(
-    name="dbt_job", 
+    name="dbt_job",
     selection=dbt_assets,
     description="Run dbt models"
-    )
+)
+
+dbt_snapshot_job = define_asset_job(
+    name="dbt_snapshot_job",
+    selection=dbt_snapshots,
+    description="Run dbt snapshots to capture SCD Type 2 changes"
+)
 
 @job
 def gcs_to_bq_load_job():
@@ -20,7 +30,8 @@ def gcs_to_bq_load_job():
 
 defs = Definitions(
     jobs=[
-        dbt_job, 
+        dbt_job,
+        dbt_snapshot_job,
         gcs_to_bq_load_job
-        ]
+    ]
 )

--- a/dagster-project/src/dagster_project/defs/schedules/__init__.py
+++ b/dagster-project/src/dagster_project/defs/schedules/__init__.py
@@ -1,9 +1,15 @@
 from dagster import ScheduleDefinition, DefaultScheduleStatus
-from dagster_project.defs.jobs import dbt_job
+from dagster_project.defs.jobs import dbt_job, dbt_snapshot_job
 
 
 daily_pipeline_schedule = ScheduleDefinition(
     job=dbt_job,
     cron_schedule="0 0 * * *",  # every day, at midnight
+    default_status=DefaultScheduleStatus.RUNNING,
+)
+
+weekly_snapshot_schedule = ScheduleDefinition(
+    job=dbt_snapshot_job,
+    cron_schedule="0 1 * * 0",  # every Sunday at 1 AM
     default_status=DefaultScheduleStatus.RUNNING,
 )


### PR DESCRIPTION
## Summary
- Adds `dbt_snapshot_job` to run dbt snapshots as Dagster assets
- Adds `weekly_snapshot_schedule` to run snapshots every Sunday at 1 AM

## Dependencies
> **Note:** Merge after PR #133 and PR #134 are merged (this job references both snapshots)

## Changes
- `dagster-project/src/dagster_project/defs/jobs/__init__.py`: Add snapshot job
- `dagster-project/src/dagster_project/defs/schedules/__init__.py`: Add weekly schedule

## Test plan
- [x] Dagster imports validate successfully
- [x] Verify job appears in Dagster UI after deployment