### PR TITLE
Add dbt docs generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ cp profiles.yml.example profiles.yml
 
 - [Analysis & Visualizations](analysis/README.md) - Dashboard screenshots and detailed insights
 - [Orchestration](docs/orchestration.md) - Dagster sensors, jobs, and scheduling patterns
+- **dbt Docs** - Run `cd dbt-project && dbt docs generate && dbt docs serve` to view model documentation and lineage locally


### PR DESCRIPTION
## Summary
Add instructions to README for generating and viewing dbt docs locally.

Generated docs contain environment-specific identifiers (project ID, schema names) so we document the generation command rather than committing the files.