### PR TITLE
fix: resolve dbt deprecation warnings

### DIFF
--- a/dbt-project/models/marts/dim_users.yml
+++ b/dbt-project/models/marts/dim_users.yml
@@ -93,7 +93,8 @@ models:
         description: "Data quality indicator. NULL when no issues detected. 'missing_sessions' if session_count is 0. 'anomalous_session_ratio' if events-per-session exceeds session_outlier_ratio var."
         tests:
           - accepted_values:
-              values: ['missing_sessions', 'anomalous_session_ratio']
+              arguments:
+                values: ['missing_sessions', 'anomalous_session_ratio']
               config:
                 where: "data_quality_flag is not null"
 

--- a/dbt-project/models/marts/fct_sessions.yml
+++ b/dbt-project/models/marts/fct_sessions.yml
@@ -82,4 +82,5 @@ models:
         description: "Furthest stage reached in the purchase funnel during the session"
         tests:
           - accepted_values:
-              values: ['purchase', 'cart', 'view', 'no_activity']
+              arguments:
+                values: ['purchase', 'cart', 'view', 'no_activity']


### PR DESCRIPTION
## Summary
- Add `arguments:` wrapper to `accepted_values` tests in `fct_sessions.yml` and `dim_users.yml` to resolve 2 `MissingArgumentsPropertyInGenericTestDeprecation` warnings
- Aligns these tests with the current dbt generic test syntax already used elsewhere in the project

## Test plan
- [x] `dbt build` passes 111/111 with 0 deprecation warnings