### PR TITLE
refactor/sessions-field-curation

### DIFF
--- a/omni/BigQuery/omni_dbt_marts/dim_user_rfm.view.yaml
+++ b/omni/BigQuery/omni_dbt_marts/dim_user_rfm.view.yaml
@@ -21,6 +21,7 @@ dimensions:
     description: Monetary score of the user
 
   rfm_score:
+    label: RFM Score
     #This description was pulled from dbt.
     description: Total RFM score calculated as the sum of recency, frequency, and
       monetary scores

--- a/omni/BigQuery/omni_dbt_marts/fct_sessions.view.yaml
+++ b/omni/BigQuery/omni_dbt_marts/fct_sessions.view.yaml
@@ -19,6 +19,7 @@ dimensions:
   session_end_time:
     #This description was pulled from dbt.
     description: Timestamp of the last event in the session
+    hidden: true
 
   unique_product_count:
     #This description was pulled from dbt.
@@ -27,37 +28,45 @@ dimensions:
   cart_additions:
     #This description was pulled from dbt.
     description: Total number of add-to-cart events during the session
+    hidden: true
 
   purchase_count:
     #This description was pulled from dbt.
     description: Total number of purchase events during the session
+    hidden: true
 
   view_count:
     #This description was pulled from dbt.
     description: Total number of view events during the session
+    hidden: true
 
   reached_view:
     #This description was pulled from dbt.
     description: Indicator (1/0) if the session included at least one view event
+    hidden: true
 
   reached_cart:
     #This description was pulled from dbt.
     description: Indicator (1/0) if the session included at least one add-to-cart event
+    hidden: true
 
   reached_purchase:
     #This description was pulled from dbt.
     description: Indicator (1/0) if the session included at least one purchase event
+    hidden: true
 
   event_count:
     #This description was pulled from dbt.
     description: Total number of events (page views, cart additions, purchases) that
       occurred during the session
+    hidden: true
 
   total_revenue:
     #This description was pulled from dbt.
     description: Revenue generated in the session. NULL for non-purchasing sessions
       (expected behavior). For purchasing sessions, represents the transaction
       value
+    hidden: true
 
   session_length:
     #This description was pulled from dbt.
@@ -75,11 +84,13 @@ dimensions:
     #This description was pulled from dbt.
     description: |
       Cleaned session identifier. Original session ID if no timeout occurred, or original_id + '_timeout_' + occurrence_number for split sessions.
+    hidden: true
 
   user_id:
     format: ID
     #This description was pulled from dbt.
     description: Identifier for the user who initiated the session
+    hidden: true
 
   is_converting_session:
     sql: CASE WHEN ${omni_dbt_marts__fct_sessions.purchase_count} > 0 THEN 1 ELSE 0
@@ -107,6 +118,7 @@ dimensions:
 
 measures:
   count:
+    label: Session Count
     aggregate_type: count
 
   total_events:
@@ -138,7 +150,7 @@ measures:
     label: Conversion Rate
     format: PERCENT
     description: Percentage of sessions that resulted in at least one purchase.
-      Calculated as (sessions with purchases / total sessions) * 100
+      Calculated as (sessions with purchases / total sessions)
 
   revenue_per_session:
     sql: SUM(${omni_dbt_marts__fct_sessions.total_revenue}) / COUNT(*)
@@ -153,7 +165,7 @@ measures:
     format: PERCENT
     description: Percentage of sessions that reached the view stage and proceeded to
       add items to cart. Calculated as (sessions reached cart / sessions reached
-      view) * 100
+      view)
 
   cart_to_purchase_rate:
     sql: SUM(CASE WHEN ${omni_dbt_marts__fct_sessions.reached_purchase} > 0 THEN 1
@@ -163,7 +175,7 @@ measures:
     format: PERCENT
     description: Percentage of sessions that reached the cart stage and completed a
       purchase. Calculated as (sessions reached purchase / sessions reached
-      cart) * 100
+      cart)
 
   avg_revenue_per_purchasing_session:
     sql: SUM(CASE WHEN ${omni_dbt_marts__fct_sessions.purchase_count} > 0 THEN

--- a/omni/BigQuery/sessions.topic.yaml
+++ b/omni/BigQuery/sessions.topic.yaml
@@ -1,6 +1,65 @@
 base_view: omni_dbt_marts__fct_sessions
 label: Sessions
+description: Analyze user sessions with 1-hour inactivity timeout for a
+  multi-category online retailer. Includes session metrics and RFM customer
+  segmentation.
+
+fields:
+  [
+    all_views.*,
+    -omni_dbt_marts__fct_sessions.session_id,
+    -omni_dbt_marts__fct_sessions.user_id,
+    -omni_dbt_marts__dim_users.total_revenue,
+    -omni_dbt_marts__dim_users.sum_revenue,
+    -omni_dbt_marts__dim_users.total_sessions,
+    -omni_dbt_marts__dim_users.avg_order_value,
+    -omni_dbt_marts__dim_users.purchase_count,
+    -omni_dbt_marts__dim_users.last_event_date,
+    -omni_dbt_marts__dim_users.last_event_time,
+    -omni_dbt_marts__dim_users.last_purchase_date,
+    -omni_dbt_marts__dim_users.first_event_date,
+    -omni_dbt_marts__dim_users.first_event_time,
+    -omni_dbt_marts__dim_users.first_purchase_date,
+    -omni_dbt_marts__dim_users.days_since_last_purchase,
+    -omni_dbt_marts__dim_users.days_since_last_activity,
+    -omni_dbt_marts__dim_users.customer_lifespan_days,
+    -omni_dbt_marts__dim_user_rfm.frequency_score,
+    -omni_dbt_marts__dim_user_rfm.monetary_score,
+    -omni_dbt_marts__dim_user_rfm.recency_score,
+    -omni_dbt_marts__dim_user_rfm.rfm_score,
+    -omni_dbt_marts__dim_users.avg_ltv,
+    -omni_dbt_marts__dim_users.avg_aov,
+    -omni_dbt_marts__dim_users.churned_user_count,
+    -omni_dbt_marts__dim_users.churn_rate,
+    -omni_dbt_marts__dim_users.purchaser_count,
+    -omni_dbt_marts__dim_users.purchaser_rate,
+    -omni_dbt_marts__dim_users.total_events,
+    -omni_dbt_marts__dim_user_rfm.user_id,
+    -omni_dbt_marts__dim_users.total_purchases,
+    -omni_dbt_marts__dim_users.user_id,
+    -omni_dbt_marts__dim_users.is_churned,
+    -omni_dbt_marts__dim_users.avg_days_since_last_purchase,
+    -omni_dbt_marts__dim_users.avg_revenue_per_user,
+    -omni_dbt_marts__dim_users.avg_customer_lifespan,
+    -omni_dbt_marts__dim_users.customer_ltv,
+    -omni_dbt_marts__dim_users.event_count,
+    -omni_dbt_marts__dim_users.session_count,
+    -omni_dbt_marts__dim_users.avg_purchase_count,
+    -omni_dbt_marts__dim_users.avg_session_count,
+    -omni_dbt_marts__dim_user_rfm.count
+  ]
 
 joins:
   omni_dbt_marts__dim_users:
     omni_dbt_marts__dim_user_rfm: {}
+
+ai_context: Use this topic to analyze user behavior and engagement patterns
+  across sessions. Analyze session metrics like duration, event counts,
+  conversion rates, and user activity patterns. Join to dim_users to understand
+  user demographics and behavior, or to dim_user_rfm to segment sessions by
+  customer value (recency, frequency, monetary scores). Filter by session
+  attributes to identify high-value sessions, analyze drop-off points, or track
+  user journeys. Use time-based filters on session start/end times to identify
+  trends and patterns. When analyzing customer segments, join to dim_user_rfm
+  for RFM segments, then to dim_users for additional user attributes like
+  lifetime value.


### PR DESCRIPTION
Clean up the Sessions topic field picker so it only shows analytically useful fields.

Global hides on fct_sessions: session_id, user_id, session_end_time, the three reached_* binary flags (measures already aggregate these), and the raw per-session counts (cart_additions, purchase_count, view_count, event_count, total_revenue).

Topic-level hides: dim_users aggregates, timestamps, and FKs that aren't relevant at session grain. dim_user_rfm individual scores hidden, kept rfm_segment and the inclusive version. dim_user_rfm.count hidden (redundant with dim_users.count).
Part of a broader refactor across all three topics. Customers and Events coming in separate branches.