### PR TITLE
fix/topic-field-curation-overrides

### DIFF
--- a/omni/BigQuery/Customers.topic.yaml
+++ b/omni/BigQuery/Customers.topic.yaml
@@ -11,8 +11,6 @@ fields:
     -omni_dbt_marts__dim_users.first_event_time,
     -omni_dbt_marts__dim_users.last_event_time,
     -omni_dbt_marts__dim_users.is_churned,
-    omni_dbt_marts__dim_users.customer_ltv,
-    omni_dbt_marts__dim_users.user_id,
     -omni_dbt_marts__dim_user_rfm.user_id,
     -omni_dbt_marts__dim_user_rfm.count
   ]

--- a/omni/BigQuery/Events.topic.yaml
+++ b/omni/BigQuery/Events.topic.yaml
@@ -27,7 +27,6 @@ fields:
     -omni_dbt_marts__dim_users.purchase_count,
     -omni_dbt_marts__dim_users.session_count,
     -omni_dbt_marts__dim_users.total_revenue,
-    omni_dbt_marts__dim_users.has_purchase_history,
     -omni_dbt_marts__dim_users.avg_aov,
     -omni_dbt_marts__dim_users.avg_customer_lifespan,
     -omni_dbt_marts__dim_users.avg_days_since_last_purchase,
@@ -43,9 +42,7 @@ fields:
     -omni_dbt_marts__dim_users.total_events,
     -omni_dbt_marts__dim_users.total_sessions,
     -omni_dbt_marts__dim_users.sum_revenue,
-    -omni_dbt_marts__dim_users.total_purchases,
-    omni_dbt_marts__dim_users.user_id,
-    omni_dbt_marts__dim_users.customer_ltv
+    -omni_dbt_marts__dim_users.total_purchases
   ]
 
 joins:


### PR DESCRIPTION
Remove explicit field includes in Customers and Events topics that were overriding view-level hides. customer_ltv (duplicate of total_revenue), user_id (technical key), and has_purchase_history (unnecessary explicit include) were being surfaced in field pickers due to a UI round-trip bug where unchecking then rechecking fields in the topic editor writes them back as positive includes. No functional changes to queries or measures.