### PR TITLE
feat: poll Omni schema refresh status and alert on failure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,6 +129,29 @@ jobs:
         echo "omni_refresh_result=timeout" >> "$GITHUB_OUTPUT"
         exit 1
 
+    - name: Notify Slack - Omni Refresh Failed
+      if: steps.omni_refresh.outputs.omni_refresh_result == 'failed' || steps.omni_refresh.outputs.omni_refresh_result == 'timeout'
+      continue-on-error: true
+      uses: slackapi/slack-github-action@v2.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ secrets.SLACK_BOT_TOKEN }}
+        payload: |
+          channel: "#estore-alerts"
+          text: "Omni schema refresh ${{ steps.omni_refresh.outputs.omni_refresh_result }}"
+          blocks:
+            - type: section
+              text:
+                type: mrkdwn
+                text: ":warning: *Omni Schema Refresh ${{ steps.omni_refresh.outputs.omni_refresh_result == 'failed' && 'Failed' || 'Timed Out' }}*\n\n*Repo:* ${{ github.repository }}\n*Commit:* `${{ github.sha }}`\n*By:* ${{ github.actor }}"
+            - type: actions
+              elements:
+                - type: button
+                  text:
+                    type: plain_text
+                    text: View Run
+                  url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     - name: Health check - Dagster webserver
       uses: appleboy/ssh-action@v1.0.0
       with:


### PR DESCRIPTION
## Summary
- After triggering the Omni schema refresh, polls `/api/v1/jobs/{jobId}/status` every 10s (up to 5 min) until `COMPLETED` or `FAILED`, replacing fire-and-forget behavior
- Adds a Slack notification to `#estore-alerts` when the refresh fails or times out
- Remains non-blocking (`continue-on-error: true`) so refresh issues don't fail the deploy

## Test plan
- [x] Merge a PR with dbt model changes and verify the refresh step polls until completion
- [ ] Confirm Slack alert fires on a simulated failure (e.g. invalid model ID)
- [x] Merge a PR with no model changes and confirm the step is skipped cleanly