### PR TITLE
Test: trigger Omni schema refresh after error handling fix

### DIFF
--- a/dbt-project/models/marts/fct_sessions.yml
+++ b/dbt-project/models/marts/fct_sessions.yml
@@ -41,7 +41,7 @@ models:
               expression: ">= session_start_time"
 
       - name: event_count
-        description: Total number of events (page views, cart additions, purchases) that occurred during
+        description: Number of events (page views, cart additions, purchases) that occurred during
           the session
         tests:
           - not_null


### PR DESCRIPTION
No-op change to dbt models to trigger the CD pipeline and verify the Omni schema refresh step works after the error handling fix in #172 