### PR TITLE
Fix Dagre layout: split dbt snapshots into own group

### DIFF
--- a/dagster-project/src/dagster_project/defs/dbt/defs.yaml
+++ b/dagster-project/src/dagster_project/defs/dbt/defs.yaml
@@ -3,4 +3,4 @@ type: dagster_dbt.DbtProjectComponent
 attributes:
   project: '{{ project_root }}/../dbt-project'
   translation:
-    group_name: dbt_models
+    group_name: "{% if node.get('resource_type') == 'snapshot' %}dbt_snapshots{% else %}dbt_models{% endif %}"


### PR DESCRIPTION
## Summary
- The `omni_analytics` group rendered side-by-side with `dbt_models` because `snap_user_rfm` (at Dagre rank 6 in `dbt_models`) shared the same rank as all `omni_analytics` assets, causing Dagre to lay the groups out horizontally instead of vertically.
- Uses conditional Jinja in the dbt translation config to assign snapshots to a `dbt_snapshots` group, keeping `dbt_models` at ranks 1–5 so `omni_analytics` flows below it.

## Test plan
- [ ] CI passes (dg list defs, dbt build)
- [ ] Verify in Dagster UI that `omni_analytics` group renders below `dbt_models` instead of beside it
- [ ] Confirm `snap_user_rfm` appears in a `dbt_snapshots` group